### PR TITLE
Update players.js

### DIFF
--- a/widgets/players/js/players.js
+++ b/widgets/players/js/players.js
@@ -371,7 +371,7 @@ vis.binds.players = {
             try {
                 browser = JSON.parse(pl);
             } catch (e) {}
-            if (typeof browser === 'object'){
+            if (browser !== null && typeof browser === 'object'){
                 $div.find('.browser-container').empty();
                 if(browser.files){
                     browser.files.forEach(function (item, i, plst){


### PR DESCRIPTION
typeof null is 'object', therefore check for `null`

closes #5